### PR TITLE
Disable download chart buttons

### DIFF
--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -60,9 +60,41 @@ format_definitions_csv <- function(reactive_dataset) {
 }
 
 #Download button for charts, just changing the icon
-savechart_button <- function(outputId, label = "Save chart", class=NULL){
-  tags$a(id = outputId, class = paste("btn btn-default shiny-download-link", class), 
-         href = "", target = "_blank", download = NA, icon("image"), label)
+savechart_button <- function(outputId, label = "Save chart", class=NULL, disabled=FALSE){
+
+  if (disabled == TRUE){
+    
+    # Message to display when disabled button is clicked
+    disabled_msg = list(p("A software update has disabled the save chart functionality. We are working on a replacement."),
+                        p("In the meantime, you can:"),
+                        tags$ul(
+                          tags$li("Download the data with the Download data button and build new charts in tools like Excel"),
+                          tags$li("Take a screenshot of the chart area using ",
+                                          tags$a(href="https://support.microsoft.com/en-us/windows/open-snipping-tool-and-take-a-screenshot-a35ac9ff-4a58-24c9-3253-f12bac9f9d44", 
+                                          "Snipping Tool"),
+                                          " or ",
+                                          tags$a(href="https://blogs.windows.com/windowsexperience/2019/04/08/windows-10-tip-snip-sketch/", 
+                                                 "Snip and Sketch."),
+                                          "At least one of these tools is usually installed on recent versions of Windows."
+                          )))
+
+    # Create button without link
+    disabled_button = tags$p(id = outputId, class = paste("btn btn-default shiny-download-link", class, "down_disabled"),
+                             icon("image"), label)
+    
+    # Define popup message box         
+    disabled_popup = bsModal(paste0(outputId, "-disabled-modal"), "Save Chart Disabled", outputId, disabled_msg, size="small")
+    
+    # need to explicitly return both ui elements otherwise only the last will be returned 
+    return(tagList(disabled_button, disabled_popup))
+    
+    
+  } else {
+    tags$a(id = outputId, class = paste("btn btn-default shiny-download-link", class),
+           href = "", target = "_blank", download = NA, icon("image"), label)
+  }
+
+
 }
 
 #Function to wrap titles, so they show completely when saving plot in ggplot

--- a/shiny_app/summary_tab.R
+++ b/shiny_app/summary_tab.R
@@ -97,9 +97,7 @@ output$profile_ui_summary <- renderUI({
 # Temporary fix for lack of saving charts functionality for snapshot and trend
 output$save_chart_ui <- renderUI({
   if (input$chart_summary %in% c("Trend", "Snapshot") ){
-    actionButton('download_summaryplot_no', 
-                 'Save chart (coming soon)',  
-                 class = "down")
+    savechart_button('download_summaryplot_no', 'Save chart',  class = "down", disabled=TRUE)
   } else if (input$chart_summary == "Spine") {
     savechart_button('download_summaryplot', 'Save chart',  class = "down")
   }

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -266,7 +266,7 @@ div(title="Use the options below to add geographies to the trend chart, remember
                       div(title="Show or hide the 95% confidence intervals for the data selected.", # tooltip
                           awesomeCheckbox("ci_trend", label = "95% confidence intervals", value = FALSE)),
                       downloadButton('download_trend', 'Download data', class = "down"),
-                      savechart_button('download_trendplot', 'Save chart',  class = "down"))),
+                      savechart_button('download_trendplot', 'Save chart',  class = "down", disabled=TRUE))),
          mainPanel(width = 8, #Main panel
                    bsModal("mod_defs_trend", "Definitions", "defs_trend", htmlOutput('defs_text_trend')),
                    h4(textOutput("title_trend"), style="color: black; text-align: left"),
@@ -318,7 +318,7 @@ tabPanel("Rank", icon = icon("signal"), value = "rank",
                   actionButton("rank_help",label="Help", icon= icon('question-circle'), class ="down"),
                   actionButton("defs_rank", label="Definitions", icon= icon('info'), class ="down"), 
                   downloadButton('download_rank', 'Download data', class = "down"),
-                  savechart_button('download_rankplot', 'Save chart', class = "down"),
+                  savechart_button('download_rankplot', 'Save chart', class = "down", disabled=TRUE),
                   savechart_button('download_mapplot', 'Save map', class = "down"),
                   data.step = 5,
                   data.intro =(p(h5("Throughout the tool look out for options in each window that provide"),

--- a/shiny_app/ui.R
+++ b/shiny_app/ui.R
@@ -366,8 +366,8 @@ tabPanel("Inequalities", icon = icon("balance-scale"), value = "ineq",
                                awesomeRadio("quint_type", label= "Local/Scotland quintiles",
                                             choices = c("Local", "Scotland"),  inline=TRUE, checkbox = TRUE)),
                       downloadButton(outputId = 'download_simd',
-                                     "Download data", class = "down")#,
-                      # savechart_button('report_simd', 'Save charts', class = "down")
+                                     "Download data", class = "down"),
+                      savechart_button('report_simd', 'Save charts', class = "down", disabled=TRUE)
          ),
          mainPanel(width = 9, #Main panel
                    bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')),

--- a/shiny_app/www/styles.css
+++ b/shiny_app/www/styles.css
@@ -53,11 +53,15 @@ body { font-size: 14px; line-height: 1.1; padding-bottom:30px}
       .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, 
        .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 
            {padding-left: 5px; padding-right: 5px;}
-                          
+
 /*Style for download buttons */
 .down{ background-color:#4da6ff; color: white; background-image:none; 
        min-width: 23vh;  font-size: 14px; padding: 5px 10px; 
        margin-top: 5px; margin-left: 3px}
+       
+ /*Colour for disabled download buttons 
+ (This must come after .down so it will override background-color) */
+.down_disabled{ background-color:#a6a6a6}
                           
 /* landing page boxes*/
 .landing-page-box { width:100%; height:100%; min-height:23vh; background-color:white;


### PR DESCRIPTION
Adds optional argument to savechart_button() allowing button to be disabled - button will be grey with a popup to explain when pressed.

Trend and Rank save chart buttons are disabled