### PR TITLE
Fix plotly tooltip

### DIFF
--- a/shiny_app/inequalities.R
+++ b/shiny_app/inequalities.R
@@ -364,7 +364,7 @@
       
       #Creating plot    
       p <- plot_ly(data=simd_bar_data(), x=~quintile,
-              text=tooltip_simd, hoverinfo="text") %>%
+              text=tooltip_simd,textposition="none", hoverinfo="text") %>%
         #Comparator line
         add_trace(y = ~average, name = "Average", type = 'scatter', mode = 'lines',
                   line = list(color = '#FF0000'), hoverinfo="skip") %>% 
@@ -426,7 +426,7 @@
         
         #Creating plot
         trend_simd_plot <- plot_ly(data=simd_trend_data(), x=~trend_axis, 
-                                   text=tooltip_simd, hoverinfo="text") %>%
+                                   text=tooltip_simd, textposition="none", hoverinfo="text") %>%
           add_lines(y = ~measure, name = "", type = 'scatter', 
                     mode = 'lines', color = ~quintile, colors = pal_simd_trend) 
         
@@ -622,7 +622,7 @@
     yaxis_plots[["title"]] <- ~type_definition
     
     par_bar_plot <- plot_ly(data = simd_parbar_data, x = ~quintile, 
-                            text=tooltip_parbar, hoverinfo="text") %>%
+                            text=tooltip_parbar,textposition="none", hoverinfo="text") %>%
       add_bars(y = ~baseline, name= "", marker = list(color = "#4da6ff"), showlegend = FALSE) %>%   
       add_bars(y = ~diff_baseline, name = "Attributable to deprivation", 
                marker = list(color = "#ffa64d"), showlegend = FALSE) %>% 
@@ -668,7 +668,7 @@
     xaxis_plots[["dtick"]] <- 2
     
     par_trend_plot <- plot_ly(data=simd_partrend_data, x=~trend_axis,
-                              text=tooltip_partrend, hoverinfo="text") %>%
+                              text=tooltip_partrend, textposition="none",hoverinfo="text") %>%
       add_lines(y = ~par, type = 'scatter', mode = 'lines', line = list(color = "#4575b4")) %>%
       layout(yaxis = yaxis_plots, xaxis = xaxis_plots, font = font_plots,
              margin = list(b = 140)) %>% #to avoid labels getting cut out

--- a/shiny_app/rank_map.R
+++ b/shiny_app/rank_map.R
@@ -268,13 +268,13 @@ plot_rank_charts <- function(){
       #Respond to user input regarding confidence intervals
       if (input$ci_rank == FALSE) {  
         #adding bar layer without confidence intervals
-        rank_plot <- rank_plot %>% add_bars(x = ~areaname, y = ~ measure, text=tooltip_bar, hoverinfo="text",
+        rank_plot <- rank_plot %>% add_bars(x = ~areaname, y = ~ measure, text=tooltip_bar, textposition="none",hoverinfo="text",
                                             marker = list(color = ~color_pal))
         
       }
       else { 
         #adding bar layer with error bars
-        rank_plot <- rank_plot %>% add_bars(x = ~areaname,y = ~ measure, text=tooltip_bar, hoverinfo="text",
+        rank_plot <- rank_plot %>% add_bars(x = ~areaname,y = ~ measure, text=tooltip_bar, textposition="none",hoverinfo="text",
                                             marker = list(color = ~color_pal), 
                                             error_y = list(type = "data",color='#000000',
                                                            symmetric = FALSE, array = ~upci_diff, arrayminus = ~lowci_diff)) 

--- a/shiny_app/summary_tab.R
+++ b/shiny_app/summary_tab.R
@@ -909,7 +909,7 @@ plot_spine <- function(){
                scales="fixed",                          # fix scale so can compare % diff down column
                labeller = label_wrap_gen(multi_line = TRUE), # allow labels to wrap 
                strip.position="left")+                    # swap strip text to appear on left
-    theme(strip.text.y = element_text(size=14,colour ='#555555', angle = 180, hjust = 0), #adjust font & rotation
+    theme(strip.text.y.left = element_text(size=14,colour ='#555555', angle = 0, hjust = 0), #adjust font & rotation
           strip.switch.pad.wrap = unit(-1, "cm"), # reducing white space between strip panel & chart
           strip.placement = "outside",  # formatting again to try and limit white space
           strip.background = element_rect(fill="grey95"))           # change colour of facet wrap background


### PR DESCRIPTION
i've made some changes to fix the profile app where the updating of the plotly package has messed with the tooltip (text is currently appearing in the bars rather than only being visible on hover).  I have also fixed an issue with the spine chart where the text orientation has become vertical when it should be horizontal - i think this must have crept in with an update of ggplot at some point.
