### PR TITLE
Fix chart download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ cookie-control.js
 deploying_app.R
 deploy.R
 
+tempPlot.png
+
 #Not needed
 rsconnect
 .Rproj.user

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -61,37 +61,37 @@ format_definitions_csv <- function(reactive_dataset) {
 #Download button for charts, just changing the icon
 savechart_button <- function(outputId, label = "Save chart", class=NULL, disabled=FALSE){
 
-  if (disabled == TRUE){
-    
-    # Message to display when disabled button is clicked
-    disabled_msg = list(p("A software update has disabled the save chart functionality. We are working on a replacement."),
-                        p("In the meantime, you can:"),
-                        tags$ul(
-                          tags$li("Download the data with the Download data button and build new charts in tools like Excel"),
-                          tags$li("Take a screenshot of the chart area using ",
-                                          tags$a(href="https://support.microsoft.com/en-us/windows/open-snipping-tool-and-take-a-screenshot-a35ac9ff-4a58-24c9-3253-f12bac9f9d44", 
-                                          "Snipping Tool"),
-                                          " or ",
-                                          tags$a(href="https://blogs.windows.com/windowsexperience/2019/04/08/windows-10-tip-snip-sketch/", 
-                                                 "Snip and Sketch."),
-                                          "At least one of these tools is usually installed on recent versions of Windows."
-                          )))
-
-    # Create button without link
-    disabled_button = tags$p(id = outputId, class = paste("btn btn-default shiny-download-link", class, "down_disabled"),
-                             icon("image"), label)
-    
-    # Define popup message box         
-    disabled_popup = bsModal(paste0(outputId, "-disabled-modal"), "Save Chart Disabled", outputId, disabled_msg, size="small")
-    
-    # need to explicitly return both ui elements otherwise only the last will be returned 
-    return(tagList(disabled_button, disabled_popup))
-    
-    
-  } else {
+  # if (disabled == TRUE){
+  #   
+  #   # Message to display when disabled button is clicked
+  #   disabled_msg = list(p("A software update has disabled the save chart functionality. We are working on a replacement."),
+  #                       p("In the meantime, you can:"),
+  #                       tags$ul(
+  #                         tags$li("Download the data with the Download data button and build new charts in tools like Excel"),
+  #                         tags$li("Take a screenshot of the chart area using ",
+  #                                         tags$a(href="https://support.microsoft.com/en-us/windows/open-snipping-tool-and-take-a-screenshot-a35ac9ff-4a58-24c9-3253-f12bac9f9d44", 
+  #                                         "Snipping Tool"),
+  #                                         " or ",
+  #                                         tags$a(href="https://blogs.windows.com/windowsexperience/2019/04/08/windows-10-tip-snip-sketch/", 
+  #                                                "Snip and Sketch."),
+  #                                         "At least one of these tools is usually installed on recent versions of Windows."
+  #                         )))
+# 
+#     # Create button without link
+#     disabled_button = tags$p(id = outputId, class = paste("btn btn-default shiny-download-link", class, "down_disabled"),
+#                              icon("image"), label)
+#     
+#     # Define popup message box         
+#     disabled_popup = bsModal(paste0(outputId, "-disabled-modal"), "Save Chart Disabled", outputId, disabled_msg, size="small")
+#     
+#     # need to explicitly return both ui elements otherwise only the last will be returned 
+#     return(tagList(disabled_button, disabled_popup))
+#     
+#     
+#   } else {
     tags$a(id = outputId, class = paste("btn btn-default shiny-download-link", class),
            href = "", target = "_blank", download = NA, icon("image"), label)
-  }
+#  }
 
 
 }

--- a/shiny_app/inequalities.R
+++ b/shiny_app/inequalities.R
@@ -355,7 +355,7 @@
       
       #Creating plot    
       p <- plot_ly(data=simd_bar_data(), x=~quintile,
-                   text=tooltip_simd, hoverinfo="text") %>%
+                   text=tooltip_simd, textposition="none",hoverinfo="text") %>%
         #Comparator line
         add_trace(y = ~average, name = "Average", type = 'scatter', mode = 'lines',
                   line = list(color = '#FF0000'), hoverinfo="skip") %>% 

--- a/shiny_app/rank_map.R
+++ b/shiny_app/rank_map.R
@@ -341,7 +341,8 @@ output$download_rankplot <- downloadHandler(
   content = function(file){
     export(p = plot_rank_charts() %>% 
              layout(title = paste0(input$indic_rank, "<br>", make_rank_subtitle()),
-                    margin = list(t = 180)),
+                    margin = list(t = 180),
+                    width = 1000, height = 800),
            file = file)
   })
 


### PR DESCRIPTION
Hey Vicky, 

Would you be able to check the downloading of charts is working ok ? I'm still using export() for now even though its deprecated because both orca and kaleido packages (the suggested alternatives) are not installing properly for me - I think IT might need to install them? It still seems to work for now though when I deploy to the test app.

I've just commented out code that was disabling the download button, which got all the charts downloading again apart from the equalities ones - I've had to do quite a bit of tweaking there and the chart titles are not sitting perfectly (for 'gap' and 'risk' they sometimes overlap the chart. Can't work out if there's a way to create more space between the titles and the chart!