### PR TITLE
Inequalities module refresh

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -264,9 +264,7 @@ andyp_data <- rbind( # merging together all indicators
   prepare_andyp_data("01_pc_access_sii_rii_opt", 1),
   prepare_andyp_data("04_prev_hosp_sii_rii_opt", 4),
   prepare_andyp_data("05_rep_hosp_sii_rii_opt", 5),
-  prepare_andyp_data("06_dying_hosp_sii_rii_opt", 6),
-  prepare_andyp_data("07_hc_amenable_mort_3-year aggregate_sii_rii_opt", 7),
-  prepare_andyp_data("08_prem_mort_3-year aggregate_sii_rii_opt", 8)) %>%
+  prepare_andyp_data("07_hc_amenable_mort_3-year aggregate_sii_rii_opt", 7)) %>%
   # patients by gp is all scotland simd
   mutate(quint_type = case_when(ind_id ==1  ~ "sc_quin",
                                 TRUE ~ quint_type))
@@ -289,11 +287,15 @@ le_inequalities_f <- readRDS("/PHI_conf/ScotPHO/Profiles/Data/Data to be checked
 ##new dying in hospital data
 dying_in_hosp_michael <-readRDS("/PHI_conf/ScotPHO/Profiles/Data/Data to be checked/dying_in_hosp_depr_ineq.rds") %>%
   rename(measure = rate)
+##new deaths <75 years
+deaths_under75_michael <-readRDS("/PHI_conf/ScotPHO/Profiles/Data/Data to be checked/deaths_under75_depr_ineq.rds") %>%
+  rename(measure = rate)
+
 ##end of temp chunk ( need to adjust line 283 too when removing this)
 
 # Merging with Andy's data and then formatting
 #data_depr <- bind_rows(data_depr, andyp_data) %>% ## JUST BEFORE THIS GOES LIVE REVERT TO THIS LINE
-data_depr <- bind_rows(data_depr, andyp_data,le_inequalities_m,le_inequalities_f,dying_in_hosp_michael) %>% ##adjust this line when removing temp chunk 
+data_depr <- bind_rows(data_depr, andyp_data,le_inequalities_m,le_inequalities_f,dying_in_hosp_michael,deaths_under75_michael) %>% ##adjust this line when removing temp chunk 
  mutate_if(is.character,factor) %>% #converting characters into factors
   mutate_at(c("numerator", "measure", "lowci", "upci", "rii", "upci_rii",
               "lowci_rii", "sii", "lowci_sii", "upci_sii", "par", "abs_range",

--- a/shiny_app/global.R
+++ b/shiny_app/global.R
@@ -154,8 +154,7 @@ ind_hsc_list <- c("Preventable emergency hospitalisation for a chronic condition
                   "Repeat emergency hospitalisation in the same year",
                   "Mortality amenable to health care",                            
                   "All-cause premature mortality",
-                  "Dying in hospital", "Mortality amenable to health care")
-
+                  "Mortality amenable to health care")
 
 # scotpho profile names -----
 profile_list <- setNames(c('HWB',
@@ -202,14 +201,11 @@ profile_areatype <- list(
                                           c('Alcohol','Drugs', "Population"))
 )
 
-  
-#  measure types -----
-
-depr_measure_types <- c("Trend", 
-                        "Gap", 
-                        "Risk") # for inequalities tab
-
-
+#  measure options for inequalities tab -----
+depr_measure_options <- c("Patterns of inequality",
+                          "Inequality gap", 
+                          "Potential for improvement",
+                          "About these options") 
 
 # 4. chart themes  ----------------------------------------------------------------
 

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -23,10 +23,9 @@ observeEvent(input$help_sii, {
     p("The values in the chart are known as the ", tags$b("'Slope Index of Inequality (SII)'"), " for each year they are calcuated using a regression model of the rank 
       of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
     p("The SII represents the inequality gap across the whole population between the most and the least disadvantaged. For example an SII
-      of 127 for the asthma hospitalisation rate means that the difference between the most and the least disadvantaged groups is 127 
+      of 127 for the asthma hospitalisation rate suggests that the difference between the most and the least disadvantaged groups is 127 
       hospitalisations per 100,000 population."),br(),
-    p("Ideally there should be no difference between indicator values in the most and least deprived areas, in this situation the SII would be zero. The larger the SII the great the disparity between the most and least deprived areas.
-      In this chart an SII that is decreasing over time would suggest that absolute inequality is reducing.
+    p("If there were no difference between indicator values in the most and least deprived areas the SII would be zero. The larger the SII the great the disparity between the most and least deprived areas.
       It is possible for absolute inequality to reduce but relative inequality to increase which is important to consider trends in both the SII and RII."),
     p("You can read more about the measures used and presented in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/", 
@@ -50,9 +49,9 @@ observeEvent(input$help_rii, {
     #trend explanation
     p("The values in the chart are known as the ", tags$b("'Relative Index of Inequality (RII)'"), "for each year this is calcuated using the a linear regression model of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
     p("The RII represents the inequality gap between the most disadvantaged and the overall average. ScotPHO use a linear regressiong model and have converted the RII
-      so that the value in the chart represents the percentage difference of the rate in the most deprived group relative to the rate in the overall population."),br(),
-    p("Ideally there should be no gap meaning an RII of zero. The larger the RII the greater the inequity between the most deprived areas and the population average.
-      It is possible for absolute inequality to reduce but relative inequality to increase which is important to consider trends in both the SII and RII."),
+      so that the value in the chart represents the percentage difference of the rate in the most disadvantaged group relative to the rate in the overall population."),br(),
+    p("If there were no difference between indicator values in the most disadvantaged area and the overall average the RII would be zero. The larger the RII the greater the inequity between the most disadvantaged areas and the overall average.
+      It is possible for relative inequality to reduce but absolute inequality to increase which is important to consider trends in both the SII and RII."),
     p("You can read more about the measures used and presented in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
              "Measuring inequalities section",  class="externallink"), 
@@ -127,7 +126,7 @@ output$inequality_options_help <- renderUI({
     p("The ", tags$b("'Inequality gap'"), " option includes charts displaying two commonly used measures of inequality - 
       the Slope Index of Inequality (SII), which represents the absolute 
       inequality gap using a regression model and the Relative Index of Inequality (RII), 
-      which quantifies the difference between the most deprived group and the overall average value. 
+      which quantifies the difference between the most disadvatnaged group and the overall average value. 
       It is possible for absolute inequalities to reduce, while relative inequalities increase (or vice-versa) which is why it is helpful to consider both the SII and RII."),
     
     #PAR/risk explanation
@@ -408,7 +407,7 @@ output$inequality_options_help <- renderUI({
         div(class= "content", htmlOutput("simd_text")))
   })
   
-  ## Controlling show/hide behaviour of dynamic summary text ----
+    ## Controlling show/hide behaviour of dynamic summary text ----
   # use shinyjs to chose when the dynamic text appears, it looks better if some options are hidden then looking at about option
   observeEvent(input$measure_simd,{
     
@@ -637,9 +636,10 @@ output$inequality_options_help <- renderUI({
   output$title_sii <- renderUI({
     div(p(tags$b("Inequalities over time: absolute differences")),
         p(paste0("The chart below shows the difference between most and least deprived areas 
-               (expressed as ", tolower(unique(simd_trend_data()$type_definition)), ")")),
+               (expressed as ", tolower(unique(simd_trend_data()$type_definition)), ").")),
         br(),
-        p("An increasing trend suggests the gap between the most and least deprived areas is growing."))
+        p("An increasing trend suggests the gap between the most and least deprived areas is growing."),
+        p("For each time period, a linear regression model is fitted and differences are calculated from the modelled estimates."))
   })
   
 
@@ -711,12 +711,13 @@ output$inequality_options_help <- renderUI({
   # RII chart title for dashboard panel
   output$title_rii <- renderUI({
     div(p(tags$b("Inequalities over time: relative differences")),
-        p(paste0("The chart below shows the differences between the most deprived area
+        p(paste0("The chart below shows the differences between the most disadvantaged area
                and the overall average for ",input$geoname_simd," (expressed as a percentage).")),
         br(),
-        p("An increasing trend suggests that the gap between the most deprived areas and the average is growing."))
+        p("An increasing trend suggests that the gap between the most disadvantaged area and the average is growing."),
+        p("For each time period, a linear regression model is fitted and percentages are calculated from the modelled estimates."))
   })
-  
+
   # rri plot
   ineq_chart_4 <- reactive({
     
@@ -1036,7 +1037,7 @@ output$inequality_options_help <- renderUI({
   )
   
   ###############################################.
-  ## Indicator definitions ----
+  ## Indicator definitions text ----
   ###############################################.
   #Subsetting by domain and profile. Profile is fiddly as vector uses abbreviations 
   # so needs to be converted to the names to match techdoc.
@@ -1049,6 +1050,25 @@ output$inequality_options_help <- renderUI({
   })
   
   
+  ###############################################.
+  ## About deprivation groupings/quintiles text ----
+  ###############################################.
+
+  output$defs_text_quintile <- renderUI({
+    tagList(
+    #simd explanation
+    p("To prepare the charts shown we divide geogrpahical areas into five groups (also known as quintiles) based on their relative levels of deprivation, as measured by the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    p("Those living in areas assigned to quntile 1 experience the highest levels of relative deprivation and those living in quintile 5 the lowest relative deprivation."),
+    p("Geogrpahical areas are assigned to a within Scotland quintile or a local quintile (e.g. within NHS board or within local authority quintile) based on the SIMD ranking."),
+    p("Indicator data for an NHS board or council area is presented by local deprivation quintiles by default. This tool allows users to switch from the default local quintiles to view the same data according to Scotland quintiles.
+      However, when using local quintiles it may not be possible to provide additional information about absolute or relative inequality (e.g. SII/RII) if
+      not all the Scotland quintiles are present in the dataset.This is often the case with areas that have smaller populations or within indicators where the event is rare.")
+    ) #close taglist
+ 
+   })
+
   
   
       

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -51,7 +51,7 @@ observeEvent(input$help_rii, {
     p("The values in the chart are known as the ", tags$b("'Relative Index of Inequality (RII)'"), "for each year this is calcuated using the a linear regression model of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
     p("The RII represents the inequality gap between the most disadvantaged and the overall average. ScotPHO use a linear regressiong model and have converted the RII
       so that the value in the chart represents the percentage difference of the rate in the most deprived group relative to the rate in the overall population."),br(),
-    p("Ideally there should be no gap meaning an RII of zero. RII typically range from between -2 and 2. The larger the RII the greater the inequity between the most deprived areas and the population average.
+    p("Ideally there should be no gap meaning an RII of zero. The larger the RII the greater the inequity between the most deprived areas and the population average.
       It is possible for absolute inequality to reduce but relative inequality to increase which is important to consider trends in both the SII and RII."),
     p("You can read more about the measures used and presented in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
@@ -397,7 +397,9 @@ output$inequality_options_help <- renderUI({
     }
   })
 
-  ## Output object for title and bullet points that can be shown/hidden depending on which conditional panel is being shown
+  
+  # Summary textbox object----
+  ## Summary text can be shown/hidden depending on which conditional panel is selected (it gives more space for explanation if user decides to select 'about these options')
   output$inequality_summary_text <- renderUI({
     div(class= "depr-text-box",
         div(class= "title", textOutput("simd_nutshell_title")),
@@ -436,13 +438,13 @@ output$inequality_options_help <- renderUI({
   ## Plots: Trend ----
   ###############################################.
   
-  #Title for barplot from trend
+  # Chart 1. barplot ----
+
+  # Title for barplot from trend (appears within dashboard)
   output$simd_barplot_title <- renderUI({
-    p(tags$b(paste0("Differences in ", tolower(input$indic_simd), 
-                    " between deprivation groups for ", input$year_simd)))
+    p(tags$b(paste0(input$indic_simd," by deprivation group for ", input$year_simd)))
   })
   
-  # Chart 1. barplot ----
   
   ineq_chart_1 <- reactive({
     
@@ -509,6 +511,13 @@ output$inequality_options_help <- renderUI({
   
   
   # Chart 2. trend plot ----
+  
+  # Title (as appears on dashboard panel)
+  output$simd_trendplot_title <- renderUI({
+    p(tags$b(paste0(input$indic_simd," over time by deprivation group")))
+  })
+  
+  
   ineq_chart_2 <- reactive({
   
     #If no data available for that period then plot message saying data is missing
@@ -568,12 +577,7 @@ output$inequality_options_help <- renderUI({
         config(displayModeBar = FALSE, displaylogo = F, editable =F) # taking out toolbar
     }
   })
-  
-  
-  #Title
-  output$simd_trendplot_title <- renderUI({
-    p(tags$b(paste0("Changes over time by deprivation group")))
-  })
+
   
   # Chart 2 - trend plot (command to displaying on the dashboard)
   output$simd_trend_plot <- renderPlotly({
@@ -581,7 +585,6 @@ output$inequality_options_help <- renderUI({
       })
   
   # Combined trend charts ----
-  
   combined_trend <- reactive({
     
     chart_1 <- ineq_chart_1() %>%
@@ -628,11 +631,13 @@ output$inequality_options_help <- renderUI({
   ## Plots: RII/SII ----
   ###############################################.
 
-  #text for title sii
+  #text for title sii (as appears on dashboard)
   output$title_sii <- renderUI({
-    div(p(tags$b("Inequality gap over time")),
-        p(paste0("Absolute differences between most and least deprived areas, 
-                 expressed as ", tolower(unique(simd_trend_data()$type_definition)), ".")))
+    div(p(tags$b("Inequalities over time: absolute differences")),
+        p(paste0("The chart below shows the difference between most and least deprived areas 
+               (expressed as ", tolower(unique(simd_trend_data()$type_definition)), ")")),
+        br(),
+        p("An increasing trend suggests the gap between the most and least deprived areas is growing."))
   })
   
 
@@ -649,26 +654,20 @@ output$inequality_options_help <- renderUI({
     
     # #Text for tooltips
       if (input$ci_simd == FALSE) {  
-        
-        tool_tip_label <- case_when(simd_index$type_id == "sr" ~ "per 100,000", 
-                                    simd_index$type_id == "cr" ~ "per 100,000",  
-                                    simd_index$type_id == "%" ~ "percent",  
-                                    simd_index$type_id == "years" ~ "years",  
-                                    TRUE ~ '')
-        
-        tooltip_sii <- paste0("Gap between least & most deprived in ",simd_index$trend_axis,"<br>", 
-                              simd_index$sii," ",tool_tip_label, "<br>", 
-                               "Also known as Slope Index of Inequality")
+
+        tooltip_sii <- paste0("Difference between most and least deprived areas,","<br>",
+                              "also known as Slope Index of Inequality (SII)", "<br>",
+                              simd_index$trend_axis, ": ", abs(simd_index$sii), "<br>", 
+                              simd_index$type_definition)
       } else { 
         tooltip_sii <- paste0(simd_index$trend_axis, ": ", simd_index$sii, "<br>",
-                                "95% confidence interval: ",
-                                simd_index$lowci_sii, "-", simd_index$upci_sii,
-                                "<br>", simd_index$type_definition, "<br>", 
+                              "95% confidence interval: ",
+                              simd_index$lowci_sii, "-", simd_index$upci_sii,
+                              "<br>", simd_index$type_definition, "<br>", 
                               "Also known as Slope Index of Inequality")
       }
 
-      
-      
+    
     #Modifying standard layout
     yaxis_plots[["title"]] <- ~type_definition
     xaxis_plots[["autotick"]] <- F
@@ -707,16 +706,14 @@ output$inequality_options_help <- renderUI({
 
 ##  Chart 4.RII plot ----
   
-  #text for title rii
+  # RII chart title for dashboard panel
   output$title_rii <- renderUI({
-    # div(p(tags$b(paste0("How the most deprived area compares with the average for ",
-    #                     input$geoname_simd)),
-    div(p(tags$b(paste0(" a")),
-          p("Relative differences between the most deprived area 
-            and the overall average for the area.")))
+    div(p(tags$b("Inequalities over time: relative differences")),
+        p(paste0("The chart below shows the differences between the most deprived area
+               and the overall average for ",input$geoname_simd," (expressed as a percentage).")),
+        br(),
+        p("An increasing trend suggests that the gap between the most deprived areas and the average is growing."))
   })
-  
-  
   
   # rri plot
   ineq_chart_4 <- reactive({
@@ -835,16 +832,11 @@ output$inequality_options_help <- renderUI({
   ###############################################.
   
   # Chart 5. Bar plot for PAR ----
-
-  #Title
+  
+  #Title (as displayed within dashboard panel)
   output$simd_par_barplot_title <- renderUI({
     div(p(tags$b(paste0("Attributable to inequality, ", input$year_simd))),
-        p("What part of ", tolower(input$indic_simd), " can be attributed to socioeconomic inequalities."))
-  })
-  output$simd_par_trendplot_title <- renderUI({
-    div(p(tags$b(paste0("Potential for improvement"))),
-        p("How much ", tolower(input$indic_simd), "could be reduced if the levels 
-          of the least deprived area were experienced across the whole population."))
+        p("What percentage of ", tolower(input$indic_simd), " can be attributed to socioeconomic inequalities."))
   })
   
   
@@ -893,15 +885,12 @@ output$inequality_options_help <- renderUI({
       layout(showlegend = F)
   })
   
-  
-  
   # Chart 6. Line plot for PAR ----
   
-  #Title
   output$simd_par_trendplot_title <- renderUI({
-    div(p(tags$b("Potential for improvement of ", tolower(input$indic_simd))),
-    p(" If the levels of the least deprived area were experienced across the whole population."))
-
+    div(p(tags$b(paste0("Potential for improvement"))),
+        p("How much ", tolower(input$indic_simd), "could be reduced if the levels 
+          of the least deprived area were experienced across the whole population."))
   })
   
   ineq_chart_6 <- reactive({ 
@@ -918,8 +907,8 @@ output$inequality_options_help <- renderUI({
       plot_nodata()
     } else { #If data is available plot it
       
-    #Tooltip
-    tooltip_partrend <- paste0(simd_partrend_data$trend_axis, "<br>",
+      #Tooltip
+      tooltip_partrend <- paste0(simd_partrend_data$trend_axis, "<br>",
                                  simd_partrend_data$par, "%")
       
     #Modifying standard layout

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -1,72 +1,211 @@
-###############################################
-#
-# Server logic for inequalities tab
-#
-###############################################
+
+## Server logic for inequalities tab ----
 
 
-
-
-  ###############################################.        
-  #### Modal ----
-  ###############################################.   
-  # Inequality help pop-up
+###############################################.        
+#### Help modals ----
+###############################################.  
+ # Inequality help pop-up
   #links to SIMD, deprivation and inequality scotpho and measuring inequalities report
-  observeEvent(input$help_simd, {
-    showModal(modalDialog(
-      title = "Interpretation and methodology",
-      p("This tool shows how ",
-        tags$a(href="https://www.scotpho.org.uk/life-circumstances/deprivation/key-points/", 
-               "inequality and deprivation",  class="externallink"), 
+observeEvent(input$help_simd, {
+  showModal(modalDialog(
+    title = "Interpretation and methodology",
+    p("This tool shows how ",
+      tags$a(href="https://www.scotpho.org.uk/life-circumstances/deprivation/key-points/", 
+             "inequality and deprivation",  class="externallink"), 
       "affect different indicators of public health. We use different measures to 
       look at various aspects of inequality. The short description on the top of 
       the page provides an overview of these calculations. "),
-      p("The 'Trend', 'Gap' and 'Risk' buttons show charts representing these 
-        different measures of inequality." ),
-      img(src="help_simd1.png"),
-      #trend explanation
-      h5("Trend", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
-      p("The ", tags$b("'Trend'"), " charts show how an indicator varies between the 
-         most and least deprived areas over time using rates or percentages."),
-      h5("Gap", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
-      #gap explanation
-      p("The ", tags$b("'Gap'"), " charts show two common measures of inequality - 
-        the Slope Index of Inequality (SII), which is used to calculate the absolute 
-        inequality gap using a regression model and the Relative Index of Inequality (RII), 
-        which is used to quantify the difference between the most deprived group 
-        and the overall average value. This means that in some cases absolute 
-        inequalities can get better, while relative inequalities get worse. "),
-      #risk explanation
-      h5("Risk", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
-      p("The ", tags$b("'Risk'"), " charts explore the potential for improvement 
-        in the overall value of an indicator, if the value of the least deprived 
-        group were experienced across the whole population. We use the Population 
-        Attributable Risk (PAR) to calculate this. "),
-      p("You can read more about the measures used and presented in the",
-        tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/", #to change
-               "Measuring inequalities section",  class="externallink"), 
-                "of the ScotPHO website."),
-      #simd explanation
-      p("To prepare the data shown in this tab we have divided the Scotland population 
-        into five groups (quintiles) based on their deprivation level. This has been done using the ",
-        tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
-               class="externallink")),
-      #quintile explanation
-      p("You can access both local and Scotland quintile data. Each local quintile 
-        represents roughly a fifth of the population of an area. They are better suited to 
-        understand the inequality patterns in a local area. "),
-      p("Scotland quintiles can be used to make comparisons between different 
-        areas on an equal basis. It is important to note, however, that some 
-        areas might not have all five quintiles represented and the populations of each 
-        quintile can vary vastly between different areas."),
-      p("We recommend using the local quintiles to understand inequalities in a specific area 
-        and only using Scotland quintiles if you need to compare between areas. Please refer to the ", 
-        tags$a(href="http://www.isdscotland.org/Products-and-Services/GPD-Support/Deprivation/SIMD/_docs/PHI-Deprivation-Guidance.pdf",
-               "ISD guidance on deprivation analysis"), " for more information on this topic."),
-        img(src="help_simd2.png"),
-      size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
-    ))
-  }) 
+    p("The 'Trend', 'Gap' and 'Risk' buttons show charts representing these 
+      different measures of inequality." ),
+    img(src="help_simd1.png"),
+    #trend explanation
+    h5("Trend", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    p("The ", tags$b("'Trend'"), " charts show how an indicator varies between the 
+      most and least deprived areas over time using rates or percentages."),
+    h5("Gap", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    #gap explanation
+    p("The ", tags$b("'Gap'"), " charts show two common measures of inequality - 
+      the Slope Index of Inequality (SII), which is used to calculate the absolute 
+      inequality gap using a regression model and the Relative Index of Inequality (RII), 
+      which is used to quantify the difference between the most deprived group 
+      and the overall average value. This means that in some cases absolute 
+      inequalities can get better, while relative inequalities get worse. "),
+    #risk explanation
+    h5("Risk", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    p("The ", tags$b("'Risk'"), " charts explore the potential for improvement 
+      in the overall value of an indicator, if the value of the least deprived 
+      group were experienced across the whole population. We use the Population 
+      Attributable Risk (PAR) to calculate this. "),
+    p("You can read more about the measures used and presented in the",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
+             "Measuring inequalities section",class="externallink"), 
+      "of the ScotPHO website."),
+    #simd explanation
+    p("To prepare the data shown in this tab we have divided the Scotland population 
+      into five groups (quintiles) based on their deprivation level. This has been done using the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    #quintile explanation
+    p("You can access both local and Scotland quintile data. Each local quintile 
+      represents roughly a fifth of the population of an area. They are better suited to 
+      understand the inequality patterns in a local area. "),
+    p("Scotland quintiles can be used to make comparisons between different 
+      areas on an equal basis. It is important to note, however, that some 
+      areas might not have all five quintiles represented and the populations of each 
+      quintile can vary vastly between different areas."),
+    p("We recommend using the local quintiles to understand inequalities in a specific area 
+      and only using Scotland quintiles if you need to compare between areas. Please refer to the ", 
+      tags$a(href="http://www.isdscotland.org/Products-and-Services/GPD-Support/Deprivation/SIMD/_docs/PHI-Deprivation-Guidance.pdf",
+             "ISD guidance on deprivation analysis"), " for more information on this topic."),
+    img(src="help_simd2.png"),
+    size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
+  ))
+}) 
+
+## Help on SII
+observeEvent(input$help_sii, {
+  showModal(modalDialog(
+    title = "Absolute inequality and the Slope Index of Inequality (SII)",
+    p("The chart below shows how the absolute inequalty (the gap between the most and least disadvantaged groups) has changed over time."),
+    #trend explanation
+    p("The values in the chart are known as the ", tags$b("'Slope Index of Inequality (SII)'"), " for each year they are calcuated using a regression model of the rank 
+      of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
+    p("The SII represents the inequality gap across the whole population between the most and the least disadvantaged. For example an SII
+      of 127 for the asthma hospitalisation rate means that the difference between the most and the least disadvantaged groups is 127 
+      hospitalisations per 100,000 population."),br(),
+    p("Ideally there should be no difference between indicator values in the most and least deprived areas, in this situation the SII would be zero. The larger the SII the great the disparity between the most and least deprived areas.
+      In this chart an SII that is decreasing over time would suggest that absolute inequality is reducing.
+      It is possible for absolute inequality to reduce but relative inequality to increase which is important to consider trends in both the SII and RII."),
+    p("You can read more about the measures used and presented in the",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/", 
+             "Measuring inequalities section",  class="externallink"), 
+      "of the ScotPHO website."),
+    #simd explanation
+    p("To prepare the data shown in this tab we have divided the Scotland population 
+      into five groups (quintiles) based on their deprivation level. This has been done using the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
+  ))
+}) 
+
+
+## Help on RII
+observeEvent(input$help_rii, {
+  showModal(modalDialog(
+    title = "Relative inequality and the Relative Index of Inequality (RII)",
+    p("The chart below shows how relative inequalty (the gap between the least disadvantaged group and the average of all groups) has changed over time."),
+    #trend explanation
+    p("The values in the chart are known as the ", tags$b("'Relative Index of Inequality (RII)'"), "for each year this is calcuated using the a linear regression model of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
+    p("The RII represents the inequality gap between the most disadvantaged and the overall average. ScotPHO use a linear regressiong model and have converted the RII
+      so that the value in the chart represents the percentage difference of the rate in the most deprived group relative to the rate in the overall population."),br(),
+    p("Ideally there should be no gap meaning an RII of zero. RII typically range from between -2 and 2. The larger the RII the greater the inequity between the most deprived areas and the population average.
+      It is possible for absolute inequality to reduce but relative inequality to increase which is important to consider trends in both the SII and RII."),
+    p("You can read more about the measures used and presented in the",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
+             "Measuring inequalities section",  class="externallink"), 
+      "of the ScotPHO website."),
+    #simd explanation
+    p("To prepare the data shown in this tab we have divided the Scotland population 
+      into five groups (quintiles) based on their deprivation level. This has been done using the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
+  ))
+}) 
+
+## Help on PAF chart 1 (snapshot year bar chart)
+observeEvent(input$help_paf, {
+  showModal(modalDialog(
+    title = "Estimating proportions attributable to inequality",
+    p("The bar chart shows indicator values split by the deprivation quintiles. The area shaded in blue is the same across all 5 quintiles, it shows the rate observed in the least deprived quintile.
+      The area shaded in orange represents the additional activity the 4 remaining quintiles have over and above that seen in the least deprived quintile."),
+    p("Looking at data in this way illustrates the potential impact of removing deprivation (i.e. in the hypothetical situation that all deprivation quintiles expereinced the same rates)."),
+    p("You can read more about the Population Attributable Risk in the",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
+             "Measuring inequalities section",  class="externallink"),"of the ScotPHO website."),
+    #simd explanation
+    p("To prepare the data shown in this tab we have divided the Scotland population 
+      into five groups (quintiles) based on their deprivation level. This has been done using the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
+  ))
+}) 
+
+## Help on PAF chart 2 (timeseries trend line chart)
+observeEvent(input$help_paf2, {
+  showModal(modalDialog(
+    title = "The Population Attributable Risk (PAR)",
+    p("The line chart shows the ",tags$b("Population Attributable Risk (PAR)"), "also known as Population Attributable Fraction (PAF)."),
+    #trend explanation
+    p("The PAR is presented as a percentage, and describes by how much the overall rate of an indicator would increase or decrease if all areas were to expereince the rates observed in the most favourable area.
+      The higher the PAR values the greater the impact of inequality on that indicator and the greater the potential fo rimpact if this inequailty could be removed."),br(),
+    p("The PAF describes a hypothetical situation and makes the assumption that all of the association between the risk factor and indicator is causal. In reality there could a number of other factors influencing the trends observed."),
+    p("You can read more about the PAR in the",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
+             "Measuring inequalities section",  class="externallink"),"of the ScotPHO website."),
+    #simd explanation
+    p("To prepare the data shown in this tab we have divided the Scotland population 
+      into five groups (quintiles) based on their deprivation level. This has been done using the ",
+      tags$a(href="https://www2.gov.scot/simd",  "Scottish Index of Multiple Deprivation (SIMD).",
+             class="externallink")),
+    size = "l", easyClose = TRUE, fade=FALSE, footer = modalButton("Close (Esc)")
+  ))
+}) 
+
+
+###############################################.
+## Which measure option to pick help text ----
+###############################################.
+
+output$inequality_options_help <- renderUI({
+  tagList(
+    h5("Which option should I look at?",style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    p("There multiple different ways that health inequality can be measured. Understanding inequality has often requires looking at more than one measure. 
+      This tool presents 3 different views of data to help users understand different aspects of inequality. 
+      We recommend considering the data options in turn as each will build on the understanding of previous."),
+    
+    #trend explanation
+    p("The ", tags$b("'Patterns of inequality'"), " option includes a bar chart showing how the measure for a particular indicator varies according to the relative deprivation of the area people live in.
+      A line chart is also available which shows the same information over time. Together these charts illustrate how rates in the most and least deprived areas compare for a single year or over time and also whether
+      there is a simple relationship between relative deprivation and a particular indicator."),
+    
+    #gap explanation
+    p("The ", tags$b("'Inequality gap'"), " option includes charts displaying two commonly used measures of inequality - 
+      the Slope Index of Inequality (SII), which represents the absolute 
+      inequality gap using a regression model and the Relative Index of Inequality (RII), 
+      which quantifies the difference between the most deprived group and the overall average value. 
+      It is possible for absolute inequalities to reduce, while relative inequalities increase (or vice-versa) which is why it is helpful to consider both the SII and RII."),
+    
+    #PAR/risk explanation
+    p("The ", tags$b("'Potential for impact'"), " option includes charts which indicate the potential for improvement for a given indicator.  
+      The measure shown is a theoretical value known as the Population Attributable Risk (PAR). 
+      Interpreting this measure requires an appreciation of whether higher indicator values are considered more desirable or less desirable.  
+      For example higher values for deaths or hospital admissions would be considered less desirable but higher values for indicators like life expectancy or immunisation update would be more desirable. 
+      The PAR produces a summary value that describes the percentage an indicator might reduce, or increase by, if the population as a whole experienced the same rate as that of the most desirable group.
+      The PAR enables generation of summary statements such as 'hospitalisations would be 50% lower if the levels of the least deprived areas were experienced across the whole population' which can be powerful in demonstrating the impact that reducing or removing inequalities might be."),
+    
+    #Deprivation
+    h5("How does ScotPHO define deprivation? ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    #p("Indicators within the inequality module of the profiles tool show rates split by the ",
+    p("This tool uses the ",
+      tags$a(href="https://www.gov.scot/collections/scottish-index-of-multiple-deprivation-2020/", "Scottish Indicies of Multiple Deprivation (SIMD)",
+             class="externallink"),
+      " to subdivide geographic areas into 5 groups (also know as quintiles) experiencing different degrees of relavtive deprivation. In this tool those living in quintile 1 tend to experience the most relative deprivation and those living in quintile 5 the least.
+      However it is important to note that SIMD is not a perfect measure of deprivation, SIMD is an area-based measure of relative deprivation and individuals living within an area may experience different levels of deprivation."),
+    
+    #Further information about measuring inequality
+    h5("Further information about measuring inequality ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    p("Additional information about ",
+      tags$a(href="http://www.healthscotland.scot/health-inequalities", "health inequalities",
+             class="externallink"),
+      " and ",
+      tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/", "measuring health inequalities",
+             class="externallink"),
+      " in Scotland."))
+})
   
   ###############################################.
   ## Indicator definitions ----

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -3,7 +3,7 @@
 # explain local/national quintiles
 # data tab needs to include inequality data
 #Summary text boxes at top: (see xx section) could this link to each section.
-#chart tooltip language? could this be improved
+#chart tooltip language? could this be improved - rii chart
 #confidence intervals for sii/rii large - possilby because app looks at quintiles but maybe deciles would be better 
 #dynamic text refers to absolute/relative gaps increasing or reducing but this doesn't factor in CI so is this really a good thing to point out
 

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -363,10 +363,10 @@ output$inequality_options_help <- renderUI({
         #statement #2 : whe absolute inequality (from sii) has increased or decreased over time
         tags$li(class= "li-custom",
                 p(paste0("Over time ", simd_text_data$statement2,". (see 'Inequality gap')"))),
-        #statement #3 based on rii
+        #statement #3 based on rii (andy P data doesn't have same fields populated so need to call on simd_text_data object rather than simd_bar_data())
         tags$li(class= "li-custom",
-                p(paste0("The most deprived areas have ", abs(round(unique(simd_bar_data()$rii_int), 0)),
-                         "% ", more_less, tolower(unique(simd_bar_data()$label_ineq)), than_as," ",input$geoname_simd," as a whole. (see 'Inequality gap')" )))
+                p(paste0("The most deprived areas have ", abs(round(unique(simd_text_data$rii_int), 0)),
+                         "% ", more_less, tolower(unique(simd_text_data$label_ineq)), than_as," ",input$geoname_simd," as a whole. (see 'Inequality gap')" )))
       )
       
     } else { #if the data is available print the following messages

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -303,10 +303,10 @@ output$inequality_options_help <- renderUI({
       #buidling components behind statement 2 around for 'gap' charts 
       # first what is max and min sii and rii for time period selected.
       # some rii/sii are negative so need to consider absolute value to maek logic work
-      mutate(sii_y_start=abs(sii[which.min(year)]),
-             sii_y_end=abs(sii[which.max(year)]),
-             rii_y_start=abs(rii_int[which.min(year)]),
-             rii_y_end=abs(rii_int[which.max(year)])) %>%
+      mutate(sii_y_start=abs(round(sii[which.min(year)],0)),
+             sii_y_end=abs(round(sii[which.max(year)],0)),
+             rii_y_start=abs(round(rii_int[which.min(year)],0)),
+             rii_y_end=abs(round(rii_int[which.max(year)],0))) %>%
       #has sii has increased or decreased
       mutate(sii_change=case_when(sii_y_start>sii_y_end ~"narrowed",
                                   sii_y_start<sii_y_end ~"widened",
@@ -317,12 +317,14 @@ output$inequality_options_help <- renderUI({
                                   rii_y_start==rii_y_end~"remained unchanged", TRUE ~"other")) %>%
       #statement 2 - what has happened with absolute and relative inequalities.
       mutate(statement2 = case_when(sii_change=="narrowed" & rii_change=="narrowed" ~ "both absolute and relative inequalities have reduced",
-                                    sii_change=="widened" & rii_change=="widened" ~ "both absolute and relative inequalities have increased",
-                                    sii_change=="remained unchanged" & rii_change=="remained unchanged" ~ "both absolute and relative inequalities have remained unchanged",
                                     sii_change=="narrowed" & rii_change=="widened" ~ "absolute inequalities have decreased but relative inequalities have increased",
                                     sii_change=="narrowed" & rii_change=="remained unchanged" ~ "absolute inequalities have decreased but relative inequalities have remained unchanged",
+                                    sii_change=="remained unchanged" & rii_change=="remained unchanged" ~ "both absolute and relative inequalities have remained unchanged",
+                                    sii_change=="remained unchanged" & rii_change=="widened" ~ "absolute inequalities have remained unchanged but relative inequalities have increased",
+                                    sii_change=="remained unchanged" & rii_change=="narrowed" ~ "absolute inequalities have remained unchanged but relative inequalities have reduced",
+                                    sii_change=="widened" & rii_change=="widened" ~ "both absolute and relative inequalities have increased",
                                     sii_change=="widened" & rii_change=="narrowed" ~ "absolute inequalities have increased but relative inequalities have decreased",
-                                    sii_change=="widened" & rii_change=="remained unchanged" ~ "absolute inequalities have increased but relative inequalities have remained unchanged", TRUE ~"N/A")) %>%
+                                    sii_change=="widened" & rii_change=="remained unchanged" ~ "absolute inequalities have increased but relative inequalities have remained unchanged", TRUE ~"N/A"))  %>%
       #statement 4 - describe % by which rates would be higher or lower in most/least deprived quintile if rates were all the same.
       #logic changes depending on if higher rates are better or worse and whether higher or lower values are most desirable.
       mutate(statement4a = case_when(interpret=="H" & par_gradient =="negative" ~ "higher", 
@@ -1033,5 +1035,21 @@ output$inequality_options_help <- renderUI({
     }
   )
   
+  ###############################################.
+  ## Indicator definitions ----
+  ###############################################.
+  #Subsetting by domain and profile. Profile is fiddly as vector uses abbreviations 
+  # so needs to be converted to the names to match techdoc.
+  output$defs_text_simd <- renderUI({
     
+    defs_data <- techdoc %>% subset(indicator_name == input$indic_simd)
+    
+    HTML(paste(sprintf("<b><u>%s</b></u> <br> %s ", defs_data$indicator_name, 
+                       defs_data$indicator_definition), collapse = "<br><br>"))
+  })
+  
+  
+  
+  
+      
 ##END

--- a/shiny_app/server scripts/inequalitiesServer.R
+++ b/shiny_app/server scripts/inequalitiesServer.R
@@ -18,7 +18,7 @@
 observeEvent(input$help_sii, {
   showModal(modalDialog(
     title = "Absolute inequality and the Slope Index of Inequality (SII)",
-    p("The chart below shows how the absolute inequalty (the gap between the most and least disadvantaged groups) has changed over time."),
+    p("The chart below shows how the absolute inequality (the gap between the most and least disadvantaged groups) has changed over time."),
     #trend explanation
     p("The values in the chart are known as the ", tags$b("'Slope Index of Inequality (SII)'"), " for each year they are calcuated using a regression model of the rank 
       of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
@@ -45,12 +45,12 @@ observeEvent(input$help_sii, {
 observeEvent(input$help_rii, {
   showModal(modalDialog(
     title = "Relative inequality and the Relative Index of Inequality (RII)",
-    p("The chart below shows how relative inequalty (the gap between the least disadvantaged group and the average of all groups) has changed over time."),
+    p("The chart below shows how relative inequality (the gap between the least disadvantaged group and the average of all groups) has changed over time."),
     #trend explanation
-    p("The values in the chart are known as the ", tags$b("'Relative Index of Inequality (RII)'"), "for each year this is calcuated using the a linear regression model of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
-    p("The RII represents the inequality gap between the most disadvantaged and the overall average. ScotPHO use a linear regressiong model and have converted the RII
+    p("The values in the chart are known as the ", tags$b("'Relative Index of Inequality (RII)'"), "for each year this is calculated using the a linear regression model of the social variable (in this case the SIMD quintiles) and the selected indicator measure (e.g. rate of hospitalisations/deaths/etc)."),br(),
+    p("The RII represents the inequality gap between the most disadvantaged and the overall average. ScotPHO use a linear regression model and have converted the RII
       so that the value in the chart represents the percentage difference of the rate in the most disadvantaged group relative to the rate in the overall population."),br(),
-    p("If there were no difference between indicator values in the most disadvantaged area and the overall average the RII would be zero. The larger the RII the greater the inequity between the most disadvantaged areas and the overall average.
+    p("If there were no difference between indicator values in the most disadvantaged area and the overall average the RII would be zero. The larger the RII the greater the inequality between the most disadvantaged areas and the overall average.
       It is possible for relative inequality to reduce but absolute inequality to increase which is important to consider trends in both the SII and RII."),
     p("You can read more about the measures used and presented in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
@@ -71,7 +71,7 @@ observeEvent(input$help_paf, {
     title = "Estimating proportions attributable to inequality",
     p("The bar chart shows indicator values split by the deprivation quintiles. The area shaded in blue is the same across all 5 quintiles, it shows the rate observed in the least deprived quintile.
       The area shaded in orange represents the additional activity the 4 remaining quintiles have over and above that seen in the least deprived quintile."),
-    p("Looking at data in this way illustrates the potential impact of removing deprivation (i.e. in the hypothetical situation that all deprivation quintiles expereinced the same rates)."),
+    p("Looking at data in this way illustrates the potential impact of removing deprivation (i.e. in the hypothetical situation that all deprivation quintiles experienced the same rates)."),
     p("You can read more about the Population Attributable Risk in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
              "Measuring inequalities section",  class="externallink"),"of the ScotPHO website."),
@@ -90,8 +90,8 @@ observeEvent(input$help_paf2, {
     title = "The Population Attributable Risk (PAR)",
     p("The line chart shows the ",tags$b("Population Attributable Risk (PAR)"), "also known as Population Attributable Fraction (PAF)."),
     #trend explanation
-    p("The PAR is presented as a percentage, and describes by how much the overall rate of an indicator would increase or decrease if all areas were to expereince the rates observed in the most favourable area.
-      The higher the PAR values the greater the impact of inequality on that indicator and the greater the potential fo rimpact if this inequailty could be removed."),br(),
+    p("The PAR is presented as a percentage, and describes by how much the overall rate of an indicator would increase or decrease if all areas were to experience the rates observed in the most favourable area.
+      The higher the PAR values the greater the impact of inequality on that indicator and the greater the potential for impact if this inequailty could be removed."),br(),
     p("The PAF describes a hypothetical situation and makes the assumption that all of the association between the risk factor and indicator is causal. In reality there could a number of other factors influencing the trends observed."),
     p("You can read more about the PAR in the",
       tags$a(href="https://www.scotpho.org.uk/comparative-health/measuring-inequalities/",
@@ -112,8 +112,9 @@ observeEvent(input$help_paf2, {
 
 output$inequality_options_help <- renderUI({
   tagList(
-    h5("Which option should I look at?",style = "font-weight: bold; color: black; margin-bottom: 0px;"),
-    p("There multiple different ways that health inequality can be measured. Understanding inequality has often requires looking at more than one measure. 
+    h3("Which option should I look at?",style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    br(),
+    p("There multiple different ways that health inequality can be measured. Understanding inequality often requires looking at more than one measure. 
       This tool presents 3 different views of data to help users understand different aspects of inequality. 
       We recommend considering the data options in turn as each will build on the understanding of previous."),
     
@@ -133,21 +134,23 @@ output$inequality_options_help <- renderUI({
     p("The ", tags$b("'Potential for impact'"), " option includes charts which indicate the potential for improvement for a given indicator.  
       The measure shown is a theoretical value known as the Population Attributable Risk (PAR). 
       Interpreting this measure requires an appreciation of whether higher indicator values are considered more desirable or less desirable.  
-      For example higher values for deaths or hospital admissions would be considered less desirable but higher values for indicators like life expectancy or immunisation update would be more desirable. 
+      For example higher values for deaths or hospital admissions would be considered less desirable but higher values for indicators like life expectancy or immunisation uptake would be more desirable. 
       The PAR produces a summary value that describes the percentage an indicator might reduce, or increase by, if the population as a whole experienced the same rate as that of the most desirable group.
       The PAR enables generation of summary statements such as 'hospitalisations would be 50% lower if the levels of the least deprived areas were experienced across the whole population' which can be powerful in demonstrating the impact that reducing or removing inequalities might be."),
     
     #Deprivation
-    h5("How does ScotPHO define deprivation? ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    h3("How does ScotPHO define deprivation? ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    br(),
     #p("Indicators within the inequality module of the profiles tool show rates split by the ",
     p("This tool uses the ",
       tags$a(href="https://www.gov.scot/collections/scottish-index-of-multiple-deprivation-2020/", "Scottish Indicies of Multiple Deprivation (SIMD)",
              class="externallink"),
-      " to subdivide geographic areas into 5 groups (also know as quintiles) experiencing different degrees of relavtive deprivation. In this tool those living in quintile 1 tend to experience the most relative deprivation and those living in quintile 5 the least.
+      " to subdivide geographic areas into 5 groups (also know as quintiles) experiencing different degrees of relative deprivation. In this tool those living in quintile 1 tend to experience the most relative deprivation and those living in quintile 5 the least.
       However it is important to note that SIMD is not a perfect measure of deprivation, SIMD is an area-based measure of relative deprivation and individuals living within an area may experience different levels of deprivation."),
     
     #Further information about measuring inequality
-    h5("Further information about measuring inequality ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    h3("Further information about measuring inequality ", style = "font-weight: bold; color: black; margin-bottom: 0px;"),
+    br(),
     p("Additional information about ",
       tags$a(href="http://www.healthscotland.scot/health-inequalities", "health inequalities",
              class="externallink"),

--- a/shiny_app/ui scripts/inequalitiesUI.R
+++ b/shiny_app/ui scripts/inequalitiesUI.R
@@ -38,10 +38,9 @@ tabPanel(div(
                savechart_button('report_simd', 'Save charts', class = "down", disabled=FALSE)
   ),
   mainPanel(width = 9, #Main panel
-            bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')),
+            style = "margin-top: 30px",
+            #bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')), ##not sure if this line is needed? seems to be unconnected to any current object
             uiOutput("inequality_summary_text"), #dynamic bullet points - appearance controlled using reactive element in inequalities server script
-            #  div(class= "title", textOutput("simd_nutshell_title")),
-            #  div(class= "content", htmlOutput("simd_text"))),
             #Overview: trend and bar chart
             conditionalPanel("input.measure_simd == 'Patterns of inequality'",
                              column(6,
@@ -50,16 +49,16 @@ tabPanel(div(
                              column(6,
                                     htmlOutput("simd_trendplot_title"),
                                     withSpinner(plotlyOutput("simd_trend_plot"))),
-                             column(12, align="center", #legend
+                             column(12, align="left", #legend hack for bar plot
                                     style= "padding-bottom: 40px;",
-                                    p(column(1),
+                                    p(#column(1),
                                       column(2, img(src="quintile1.png", height = "16px"), "1 - most deprived"), 
                                       column(1, img(src="quintile2.png", height = "16px"), "2"),
                                       column(1, img(src="quintile3.png", height = "16px"), "3"),
                                       column(1, img(src="quintile4.png", height = "16px"), "4"),
                                       column(2, img(src="quintile5.png", height = "16px"), "5 - least deprived"),
                                       column(2, img(src="simd_overall.png", height = "8px"), "Average"),
-                                      column(1)))
+                                      column(3)))
             ),#trend minitab bracket
             
             #Absolute and realtive inequality

--- a/shiny_app/ui scripts/inequalitiesUI.R
+++ b/shiny_app/ui scripts/inequalitiesUI.R
@@ -20,7 +20,7 @@ tabPanel(div(
                uiOutput("geoname_ui_simd"),
                selectInput("indic_simd", label = "Step 2 - Choose an indicator (type to search)",
                            choices = ind_depr_list),
-               actionButton("defs_simd",label="Indicator definitions", icon= icon('info'), class ="down"),
+               actionButton("defs_simd",label="Definitions", icon= icon('info'), class ="down"), #action button linked to module - needed to dislpay pop up with indicator description
                uiOutput("year_ui_simd"),
                div(title="Select what aspect of inequality you want to explore.", # tooltip
                    style = "margin-top: 10px; margin-bottom: 20px;", 
@@ -39,7 +39,7 @@ tabPanel(div(
   ),
   mainPanel(width = 9, #Main panel
             style = "margin-top: 30px",
-            #bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')), ##not sure if this line is needed? seems to be unconnected to any current object
+            bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')), #modal box that pops up containting indicator definitions text
             uiOutput("inequality_summary_text"), #dynamic bullet points - appearance controlled using reactive element in inequalities server script
             #Overview: trend and bar chart
             conditionalPanel("input.measure_simd == 'Patterns of inequality'",

--- a/shiny_app/ui scripts/inequalitiesUI.R
+++ b/shiny_app/ui scripts/inequalitiesUI.R
@@ -28,7 +28,7 @@ tabPanel(div(
                    style = "margin-top: 10px; margin-bottom: 20px;", 
                    radioGroupButtons("measure_simd", 
                                      label= "Step 4 - Select what aspect of inequality you want to explore.", 
-                                     choices = depr_measure_types, status = "primary",
+                                     choices = depr_measure_options, status = "primary",direction = "vertical",
                                      justified = TRUE
                    )),
                awesomeCheckbox("ci_simd", label = "Show/hide 95% confidence intervals", value = F),
@@ -45,7 +45,7 @@ tabPanel(div(
             div(class= "depr-text-box",
                 div(class= "title", textOutput("simd_nutshell_title")),
                 div(class= "content", htmlOutput("simd_text"))),
-            conditionalPanel("input.measure_simd == 'Trend'",
+            conditionalPanel("input.measure_simd == 'Patterns of inequality'",
                              column(6,
                                     htmlOutput("simd_barplot_title"),
                                     withSpinner(plotlyOutput("simd_bar_plot"))),
@@ -63,25 +63,55 @@ tabPanel(div(
                                       column(2, img(src="simd_overall.png", height = "8px"), "Average"),
                                       column(1)))
             ),#trend minitab bracket
+            
             #Absolute and realtive inequality
-            conditionalPanel("input.measure_simd == 'Gap'",
-                             column(6, htmlOutput("title_sii"), br(),
-                                    withSpinner(plotlyOutput("simd_sii_plot"))), 
+            conditionalPanel("input.measure_simd ==  'Inequality gap'",
                              column(6, 
+                                    br(),#improve alignment with selection menu
+                                    htmlOutput("title_sii"),
+                                    br(),
+                                    actionButton("help_sii", label="What does this chart show?", 
+                                                 icon= icon('question-circle'), class ="down"), 
+                                    br(),
+                                    withSpinner(plotlyOutput("simd_sii_plot"))), 
+                             column(6,
+                                    br(),#improve alignment with selection menu
                                     htmlOutput("title_rii"),
+                                    br(),
+                                    actionButton("help_rii", label="What does this chart show?", 
+                                                 icon= icon('question-circle'), class ="down"), 
+                                    br(),
                                     withSpinner(plotlyOutput("simd_rii_plot"))) 
             ),
+            
             #Population attributable risk
-            conditionalPanel("input.measure_simd == 'Risk'",
+            conditionalPanel("input.measure_simd == 'Potential for improvement'",
                              column(6,
+                                    br(),#improve alignment with sidepanel dropdowns 
                                     htmlOutput("simd_par_barplot_title"),
-                                    withSpinner(plotlyOutput("simd_par_barplot")),
-                                    p(img(src= "signif_worse.png", height = "16px"),
-                                      "Attributable to inequality", 
-                                      style= "text-align: center; padding-bottom: 40px")),
+                                    actionButton("help_paf", label="What does this chart show?", 
+                                                 icon= icon('question-circle'), class ="down"),
+                                    p(img(src= "signif_better.png", height = "16px"),"Baseline",
+                                      img(src= "signif_worse.png", height = "16px"),"Attributable to inequality",
+                                      style= "text-align: left; padding-top: 10px; padding-bottom: 10px"),
+                                    withSpinner(plotlyOutput("simd_par_barplot"))
+                             ),
                              column(6,
+                                    br(),#improve alignment with sidepanel dropdowns
                                     htmlOutput("simd_par_trendplot_title"),
+                                    actionButton("help_paf2", label="What does this chart show?", 
+                                                 icon= icon('question-circle'), class ="down"),
+                                    p(" "), # create whitespace and help alignment of charts
+                                    br(),
                                     withSpinner(plotlyOutput("simd_par_trendplot")))
+            ),
+            
+          #Which measure to look at
+            conditionalPanel("input.measure_simd == 'About these options'",
+                             column(12,
+                                    uiOutput("inequality_options_help") # text displayed generated in inequalities server script
+                             ) # close column
+                             
             )
   )
 ) #Tab panel bracket

--- a/shiny_app/ui scripts/inequalitiesUI.R
+++ b/shiny_app/ui scripts/inequalitiesUI.R
@@ -27,12 +27,12 @@ tabPanel(div(
                    radioGroupButtons("measure_simd", 
                                      label= "Step 4 - Select what aspect of inequality you want to explore.", 
                                      choices = depr_measure_options, status = "primary",direction = "vertical",
-                                     justified = TRUE
-                   )),
+                                     justified = TRUE)),
                awesomeCheckbox("ci_simd", label = "Show/hide 95% confidence intervals", value = F),
                tags$div(title="Select if you want to use local or national quintiles", # tooltip
-                        awesomeRadio("quint_type", label= "Local/Scotland quintiles",
-                                     choices = c("Local", "Scotland"),  inline=TRUE, checkbox = TRUE)),
+                         awesomeRadio("quint_type", label= "Local/Scotland quintiles",
+                                      choices = c("Local", "Scotland"),  inline=TRUE, checkbox = TRUE)),
+               actionButton("defs_quintile",label="Deprivation grouping", icon= icon('info'), class ="down"), #action button linked to module - needed to dislpay pop up with indicator description
                downloadButton(outputId = 'download_simd',
                               "Download data", class = "down"),
                savechart_button('report_simd', 'Save charts', class = "down", disabled=FALSE)
@@ -40,6 +40,7 @@ tabPanel(div(
   mainPanel(width = 9, #Main panel
             style = "margin-top: 30px",
             bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')), #modal box that pops up containting indicator definitions text
+            bsModal("mod_defs_quintile", "About deprivation groupings", "defs_quintile", htmlOutput('defs_text_quintile')), #modal box that pops up containting indicator definitions text
             uiOutput("inequality_summary_text"), #dynamic bullet points - appearance controlled using reactive element in inequalities server script
             #Overview: trend and bar chart
             conditionalPanel("input.measure_simd == 'Patterns of inequality'",

--- a/shiny_app/ui scripts/inequalitiesUI.R
+++ b/shiny_app/ui scripts/inequalitiesUI.R
@@ -14,15 +14,13 @@ tabPanel(div(
   "Inequalities"),
   value = "ineq",
   sidebarPanel(width = 3, #Filter options
-               actionButton("help_simd", label="Help", 
-                            icon= icon('question-circle'), class ="down"), 
-               actionButton("defs_simd",label="Definitions", icon= icon('info'), class ="down"),
                div(style = "margin-top: 30px",
                    selectInput("geotype_simd", label = "Step 1 - Select a geography level and an area",
                                choices = areatype_depr_list, selected =  "Scotland")),
                uiOutput("geoname_ui_simd"),
                selectInput("indic_simd", label = "Step 2 - Choose an indicator (type to search)",
                            choices = ind_depr_list),
+               actionButton("defs_simd",label="Indicator definitions", icon= icon('info'), class ="down"),
                uiOutput("year_ui_simd"),
                div(title="Select what aspect of inequality you want to explore.", # tooltip
                    style = "margin-top: 10px; margin-bottom: 20px;", 
@@ -41,10 +39,10 @@ tabPanel(div(
   ),
   mainPanel(width = 9, #Main panel
             bsModal("mod_defs_simd", "Definitions", "defs_simd", htmlOutput('defs_text_simd')),
+            uiOutput("inequality_summary_text"), #dynamic bullet points - appearance controlled using reactive element in inequalities server script
+            #  div(class= "title", textOutput("simd_nutshell_title")),
+            #  div(class= "content", htmlOutput("simd_text"))),
             #Overview: trend and bar chart
-            div(class= "depr-text-box",
-                div(class= "title", textOutput("simd_nutshell_title")),
-                div(class= "content", htmlOutput("simd_text"))),
             conditionalPanel("input.measure_simd == 'Patterns of inequality'",
                              column(6,
                                     htmlOutput("simd_barplot_title"),


### PR DESCRIPTION
•	Additional indicators where higher values are considered desirable (e.g. life expectancy, immunisations, screening) the tool shouldn’t freak out now these are included and the charts should still make sense
•	So far 2 of the andy Pulford indicators have been recalculated and updated (dying in hospital and premature mortality (now called deaths <75 years)
•	I have rewritten a lot of the explanatory text/titles to try and help people figure out what they are looking at and what it tells them
•	The dynamic summary text ‘should’ be more helpful and respond to individual indicators without being gibberish
•	I’ve played about with the drop down panel a bit
