### PR TITLE
Mm indicator updates schedule

### DIFF
--- a/data_preparation/data_preparation.R
+++ b/data_preparation/data_preparation.R
@@ -73,13 +73,19 @@ technical_doc <- technical_doc |>
 technical_doc <- technical_doc |>
   mutate(
     last_updated_temp = suppressWarnings(convertToDate(last_updated)), 
-    days_since_update = difftime(Sys.Date(), last_updated_temp),
+    days_since_update = difftime(Sys.Date(), last_updated_temp)) |>
+  mutate(
     across(
-      c("last_updated", "next_update", "source_next_update", "source_last_updated"), 
-      ~ suppressWarnings(strftime(convertToDate(.), "%b-%Y"))
+      .cols = c("last_updated", "next_update", "source_next_update"),
+      .fns = ~ suppressWarnings(
+        case_when(
+          !is.na(as.numeric(.)) ~ strftime(convertToDate(.), "%b-%Y"), TRUE ~ .
+        )
+      )
     )
   ) |>
-  select(-last_updated_temp)
+  select(-c(last_updated_temp, data_request_needed, if_so_who, r_script_name))
+
 
 ## Save file -----
 write_parquet(technical_doc, "shiny_app/data/techdoc") # version for shiny app

--- a/shiny_app/server scripts/definitionsServer.R
+++ b/shiny_app/server scripts/definitionsServer.R
@@ -20,7 +20,9 @@ output$btn_techdoc_download <- downloadHandler(
   
   filename ="Indicator_definitions.csv",
   content = function(file) {
-    write.csv(ind_dat %>% select(-ind_id, - profile_short), 
+    write.csv(ind_dat |> 
+              filter(profile_short != "Show all") |>
+                select(-ind_id, - profile_short),
               file, row.names=FALSE) }
 )
 
@@ -174,7 +176,7 @@ output$ind_search_results <- renderReactable({
                      
 }")),
       # 2. format date column
-      next_update = colDef(defaultSortOrder = "desc", sortable = TRUE, name = "Next update due", na = "TBC"),
+      next_update = colDef(defaultSortOrder = "desc", sortable = TRUE, name = "Next update due"),
       
       # 3. hide all other columns in the table. 
       profile = colDef(show = F),


### PR DESCRIPTION
Hi Vicky, 

Some small amendments to make sure that any update dates that are 'TBC' or 'Summer 2024' actually display in the table on the indicator definitions tab, rather than displaying as 'NA'. Have also fixed an issue with duplicate rows appearing in the definitions download.

Most of the changes are in the tech doc itself rather than here. Have re-allocated and shifted update dates, and added a few extra columns since most people running updates will be new to the process. The new columns just have some info on R script name, if the data needs to be requested and from which team. Have only populated those columns for Feb/March and can build on it throughout the year. 

P.s I've lost the stripey-ness on the techdoc when I was making changes and don't know how to get it back!